### PR TITLE
update package list

### DIFF
--- a/SIMRS25.csproj
+++ b/SIMRS25.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="DevExpress.Win.Design" Version="24.2.7" />
     <PackageReference Include="DotNetEnv" Version="3.1.1" />
+    <PackageReference Include="LijsDev.CrystalReportsRunner.13.0.32.x64" Version="1.4.9" />
     <PackageReference Include="MySql.Data" Version="9.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="UI.for.WinForms.AllControls.Net80">


### PR DESCRIPTION
- add CrystalReportsRunner package

Runner to allow the use of Crystal Reports in .NET Core using external process (in .NET Framework 4.8) and named pipes for communication.

If you are using Crystal Reports in your application you're probably stuck with .NET Framework 4.x. However, all the new features are in the .NET Core framework nowadays and you might want to take advantage of them by upgrading your app to use the latest version of .NET.

Unfortunately, Crystal Reports doesn't support .NET Core so one workaround is to isolate it into its own executable so that your own application doesn't need to have a dependency on Crystal Reports SDK.